### PR TITLE
Make interpretRoll recursive.

### DIFF
--- a/TorchbearerTables_2E.html
+++ b/TorchbearerTables_2E.html
@@ -739,179 +739,69 @@
   ];
   const LootTable = [
     [ // Loot Table 1
-      function () {
-        interpretRoll(lootBooksMaps)
-      },
-      function () {
-        interpretRoll(lootGear)
-      },
-      function () {
-        interpretRoll(lootGear)
-      },
-      function () {
-        interpretRoll(lootGear)
-      },
-      function () {
-        interpretRoll(lootGear)
-      },
-      function () {
-        interpretRoll(lootStuff)
-      },
-      function () {
-        interpretRoll(lootStuff)
-      },
-      function () {
-        interpretRoll(lootStuff)
-      },
-      function () {
-        interpretRoll(lootStuff)
-      },
-      function () {
-        interpretRoll(treasureAndValuables1)
-      },
-      function () {
-        interpretRoll(lootMagic)
-      }
+      () => interpretRoll(lootBooksMaps),
+      () => interpretRoll(lootGear),
+      () => interpretRoll(lootGear),
+      () => interpretRoll(lootGear),
+      () => interpretRoll(lootGear),
+      () => interpretRoll(lootStuff),
+      () => interpretRoll(lootStuff),
+      () => interpretRoll(lootStuff),
+      () => interpretRoll(lootStuff),
+      () => interpretRoll(treasureAndValuables1),
+      () => interpretRoll(lootMagic),
     ],
     [ // Loot Table 2
-      function () {
-        interpretRoll(lootBooksMaps)
-      },
-      function () {
-        interpretRoll(lootBooksMaps)
-      },
-      function () {
-        interpretRoll(lootStuff)
-      },
-      function () {
-        interpretRoll(lootStuff)
-      },
-      function () {
-        interpretRoll(lootGear)
-      },
-      function () {
-        interpretRoll(lootGear)
-      },
-      function () {
-        interpretRoll(lootGear)
-      },
-      function () {
-        interpretRoll(lootGear)
-      },
-      function () {
-        interpretRoll(treasureAndValuables1)
-      },
-      function () {
-        interpretRoll(treasureAndValuables1)
-      },
-      function () {
-        interpretRoll(lootMagic)
-      }
+      () => interpretRoll(lootBooksMaps),
+      () => interpretRoll(lootBooksMaps),
+      () => interpretRoll(lootStuff),
+      () => interpretRoll(lootStuff),
+      () => interpretRoll(lootGear),
+      () => interpretRoll(lootGear),
+      () => interpretRoll(lootGear),
+      () => interpretRoll(lootGear),
+      () => interpretRoll(treasureAndValuables1),
+      () => interpretRoll(treasureAndValuables1),
+      () => interpretRoll(lootMagic),
     ],
     [ // Loot Table 3
-      function () {
-        interpretRoll(lootStuff)
-      },
-      function () {
-        interpretRoll(lootStuff)
-      },
-      function () {
-        interpretRoll(lootBooksMaps)
-      },
-      function () {
-        interpretRoll(lootBooksMaps)
-      },
-      function () {
-        interpretRoll(lootGear)
-      },
-      function () {
-        interpretRoll(lootGear)
-      },
-      function () {
-        interpretRoll(lootGear)
-      },
-      function () {
-        interpretRoll(treasureAndValuables1)
-      },
-      function () {
-        interpretRoll(treasureAndValuables1)
-      },
-      function () {
-        interpretRoll(treasureAndValuables2)
-      },
-      function () {
-        interpretRoll(lootMagic)
-      }
+      () => interpretRoll(lootStuff),
+      () => interpretRoll(lootStuff),
+      () => interpretRoll(lootBooksMaps),
+      () => interpretRoll(lootBooksMaps),
+      () => interpretRoll(lootGear),
+      () => interpretRoll(lootGear),
+      () => interpretRoll(lootGear),
+      () => interpretRoll(treasureAndValuables1),
+      () => interpretRoll(treasureAndValuables1),
+      () => interpretRoll(treasureAndValuables2),
+      () => interpretRoll(lootMagic),
     ],
     [ // Loot Table 4
-      function () {
-        interpretRoll(lootGear)
-      },
-      function () {
-        interpretRoll(lootGear)
-      },
-      function () {
-        interpretRoll(treasureAndValuables1)
-      },
-      function () {
-        interpretRoll(treasureAndValuables3)
-      },
-      function () {
-        interpretRoll(treasureAndValuables3)
-      },
-      function () {
-        interpretRoll(treasureAndValuables2)
-      },
-      function () {
-        interpretRoll(treasureAndValuables2)
-      },
-      function () {
-        interpretRoll(treasureAndValuables2)
-      },
-      function () {
-        interpretRoll(lootBooksMaps)
-      },
-      function () {
-        interpretRoll(lootMagic)
-      },
-      function () {
-        interpretRoll(lootMagic)
-      }
+      () => interpretRoll(lootGear),
+      () => interpretRoll(lootGear),
+      () => interpretRoll(treasureAndValuables1),
+      () => interpretRoll(treasureAndValuables3),
+      () => interpretRoll(treasureAndValuables3),
+      () => interpretRoll(treasureAndValuables2),
+      () => interpretRoll(treasureAndValuables2),
+      () => interpretRoll(treasureAndValuables2),
+      () => interpretRoll(lootBooksMaps),
+      () => interpretRoll(lootMagic),
+      () => interpretRoll(lootMagic),
     ],
     [ // Loot Table 5
-      function () {
-        interpretRoll(lootBooksMaps)
-      },
-      function () {
-        interpretRoll(lootBooksMaps)
-      },
-      function () {
-        interpretRoll(treasureAndValuables2)
-      },
-      function () {
-        interpretRoll(treasureAndValuables3)
-      },
-      function () {
-        interpretRoll(treasureAndValuables4)
-      },
-      function () {
-        interpretRoll(treasureAndValuables4)
-      },
-      function () {
-        interpretRoll(treasureAndValuables4)
-      },
-      function () {
-        interpretRoll(lootMagic)
-      },
-      function () {
-        interpretRoll(lootMagic)
-      },
-      function () {
-        interpretRoll(lootMagic)
-      },
-      function () {
-        interpretRoll(lootMagic)
-      }
+      () => interpretRoll(lootBooksMaps),
+      () => interpretRoll(lootBooksMaps),
+      () => interpretRoll(treasureAndValuables2),
+      () => interpretRoll(treasureAndValuables3),
+      () => interpretRoll(treasureAndValuables4),
+      () => interpretRoll(treasureAndValuables4),
+      () => interpretRoll(treasureAndValuables4),
+      () => interpretRoll(lootMagic),
+      () => interpretRoll(lootMagic),
+      () => interpretRoll(lootMagic),
+      () => interpretRoll(lootMagic),
     ]
   ]
   const lootBooksMaps = [
@@ -933,197 +823,87 @@
     'Lost spell book(s): containing 2d3 spells of circles 2 through 4 (game master&8217;s choice) | X | pack 2'
   ];
   const lootGear = [
-    function () {
-      interpretRoll(treasureAndValuables2)
-    },
-    ['Thieve&8217; Tools', 'Ladder', 'Holy Water', 'Wolfsbane', 'Musical Instrument', 'Grappling Hook'],
+    () => interpretRoll(treasureAndValuables2),
+    ['Thieves\' Tools', 'Ladder', 'Holy Water', 'Wolfsbane', 'Musical Instrument', 'Grappling Hook'],
     'Battle Regalia (helmet or shield, game master chooses)',
     ['Large Sack', 'Small Sack', 'Purse', 'Satchel', 'Backpack', 'Chest'],
-    function () {
-      amountAndType(1, 3, fortunateFood, 1, 6)
-    },
+    () => amountAndType(1, 3, fortunateFood, 1, 6),
     ['iron spikes', 'hammer', 'pry bar', 'chalk', 'rope', 'tinderbox'],
-    function () {
-      amountAndType(1, 3, lightSource, 1, 6)
-    },
+    () => amountAndType(1, 3, lightSource, 1, 6),
     ['skill supplies', 'skill supplies', 'skill supplies', 'skill supplies', 'spell materials', 'sacramentals'],
-    function () {
-      interpretRoll(lootClothing)
-    },
+    () => interpretRoll(lootClothing),
     ['waterskin', 'clay pot', 'wooden canteen', 'bottle', 'jug', 'barrel'],
-    function () {
-      interpretRoll(lootWeapons)
-    },
+    () => interpretRoll(lootWeapons),
     'Tools. Skill gear or tools, game master chooses.',
-    function () {
-      interpretRoll(lootArmors)
-    },
+    () => interpretRoll(lootArmors),
     'Animal. Dog, mule, cat, or starved horse. Game master chooses.',
-    function () {
-      return `Hidden Dwarven or Elven ${lootWeapons[roll(2, 6, -2)]}`
-    },
-    function () {
-      return `Hidden Dwarven or Elven ${lootArmors[roll(1, 6, -1)]}`
-    }
+    () => `Hidden Dwarven or Elven ${lootWeapons[roll(2, 6, -2)]}`,
+    () => `Hidden Dwarven or Elven ${lootArmors[roll(1, 6, -1)]}`,
   ];
   const lootMagic = [
-    function () {
-      interpretRoll(lootCursedItem)
-    },
-    ['Drowner&8217;s Friend', 'Drowner&8217;s Friend', 'Jade Ward', 'Jade Ward', 'Amulet of Stars', 'Aegis Bracers'],
-    ['Wizard&8217;s Staff', 'Wizard&8217;s Staff', 'Wand of Unbinding', 'Wand of Unbinding', 'Dowsing Rod', 'Dowsing Rod'],
-    function () {
-      `Spell book: ${roll(1, 3)} circles of spells (game master&8217;s choice)`
-    },
-    function () {
-      return `Enchanted ${lootClothing[roll(1, 6, -1)]}`
-    },
-    function () {
-      interpretRoll(lootPotions)
-    },
-    function () {
-      return `Scroll, ${lootScroll[roll(1, 6, -1)]}`
-    },
+    () => interpretRoll(lootCursedItem),
+    ['Drowner\'s Friend', 'Drowner&8217;s Friend', 'Jade Ward', 'Jade Ward', 'Amulet of Stars', 'Aegis Bracers'],
+    ['Wizard\'s Staff', 'Wizard&8217;s Staff', 'Wand of Unbinding', 'Wand of Unbinding', 'Dowsing Rod', 'Dowsing Rod'],
+    () => `Spell book: ${roll(1, 3)} circles of spells (game master&8217;s choice)`,
+    () => `Enchanted ${lootClothing[roll(1, 6, -1)]}`,
+    () => interpretRoll(lootPotions),
+    () => `Scroll, ${lootScroll[roll(1, 6, -1)]}`,
     ['minor relic', 'minor relic', 'minor relic', 'minor relic', 'named relic', 'great relic'],
     ['Horn of Drenge', 'Burglar&8217;s Gloves', 'Elven Rope', 'Girdle of Troll Might', 'Haversack of Holding', 'Elven cloak'],
-    ['Mind Sword', 'Blood-Seeking Sword', 'Blood-Seeking Sword', 'Celestial Mace', 'Slaughterer&8217;s Friend', function () {
-      return `Dwarven or Elven ${lootWeapons[roll(2, 6, -2)]}`
-    }],
+    ['Mind Sword', 'Blood-Seeking Sword', 'Blood-Seeking Sword', 'Celestial Mace', 'Slaughterer&8217;s Friend', () => `Dwarven or Elven ${lootWeapons[roll(2, 6, -2)]}`],
     ['Enchanted shield', 'Enchanted helmet', ' Enchanted leather armor', 'Enchanted chain armor', 'Enchanted plate armor', 'Forge mask']
   ];
   const fortunateFood = ['forage', 'game', 'fresh rations', 'preserved rations', 'garlic', 'salt'];
   const lightSource = ['candles', 'candles', 'candles', 'candles', 'torches', 'flasks of oil'];
   const treasureAndValuables1 = [
-    function () {
-      interpretRoll(lootJewelry1)
-    },
-    function () {
-      interpretRoll(lootJewelry1)
-    },
-    function () {
-      interpretRoll(lootCoins1)
-    },
-    function () {
-      interpretRoll(lootCoins1)
-    },
-    function () {
-      interpretRoll(lootCoins1)
-    },
-    function () {
-      interpretRoll(lootCoins1)
-    },
-    function () {
-      interpretRoll(lootCoins1)
-    },
-    function () {
-      interpretRoll(lootGems1)
-    },
-    function () {
-      interpretRoll(lootGems1)
-    },
-    function () {
-      interpretRoll(lootBooksMaps)
-    },
-    function () {
-      interpretRoll(lootBooksMaps)
-    }
+    () => interpretRoll(lootJewelry1),
+    () => interpretRoll(lootJewelry1),
+    () => interpretRoll(lootCoins1),
+    () => interpretRoll(lootCoins1),
+    () => interpretRoll(lootCoins1),
+    () => interpretRoll(lootCoins1),
+    () => interpretRoll(lootCoins1),
+    () => interpretRoll(lootGems1),
+    () => interpretRoll(lootGems1),
+    () => interpretRoll(lootBooksMaps),
+    () => interpretRoll(lootBooksMaps),
   ];
   const treasureAndValuables2 = [
-    function () {
-      interpretRoll(lootJewelry1)
-    },
-    function () {
-      interpretRoll(lootJewelry1)
-    },
-    function () {
-      interpretRoll(lootJewelry1)
-    },
-    function () {
-      interpretRoll(lootCoins1)
-    },
-    function () {
-      interpretRoll(lootCoins1)
-    },
-    function () {
-      interpretRoll(lootCoins2)
-    },
-    function () {
-      interpretRoll(lootCoins2)
-    },
-    function () {
-      interpretRoll(lootGems1)
-    },
-    function () {
-      interpretRoll(lootGems1)
-    },
-    function () {
-      interpretRoll(lootBooksMaps)
-    },
-    function () {
-      interpretRoll(lootPotions)
-    }
+    () => interpretRoll(lootJewelry1),
+    () => interpretRoll(lootJewelry1),
+    () => interpretRoll(lootJewelry1),
+    () => interpretRoll(lootCoins1),
+    () => interpretRoll(lootCoins1),
+    () => interpretRoll(lootCoins2),
+    () => interpretRoll(lootCoins2),
+    () => interpretRoll(lootGems1),
+    () => interpretRoll(lootGems1),
+    () => interpretRoll(lootBooksMaps),
+    () => interpretRoll(lootPotions),
   ];
   const treasureAndValuables3 = [
     'Finery (1d6)',
-    function () {
-      interpretRoll(lootJewelry2)
-    },
-    function () {
-      interpretRoll(lootBooksMaps)
-    },
-    function () {
-      interpretRoll(lootSilverPlate)
-    },
-    function () {
-      interpretRoll(lootRugsTapestries)
-    },
-    function () {
-      interpretRoll(lootCoins3)
-    },
-    function () {
-      interpretRoll(lootCoins4)
-    },
-    function () {
-      interpretRoll(lootArt)
-    },
-    function () {
-      interpretRoll(lootGems1)
-    },
-    function () {
-      interpretRoll(lootTitlesDeeds)
-    },
-    function () {
-      interpretRoll(lootMagic)
-    }
+    () => interpretRoll(lootJewelry2),
+    () => interpretRoll(lootBooksMaps),
+    () => interpretRoll(lootSilverPlate),
+    () => interpretRoll(lootRugsTapestries),
+    () => interpretRoll(lootCoins3),
+    () => interpretRoll(lootCoins4),
+    () => interpretRoll(lootArt),
+    () => interpretRoll(lootGems1),
+    () => interpretRoll(lootTitlesDeeds),
+    () => interpretRoll(lootMagic),
   ];
   const treasureAndValuables4 = [
-    function () {
-      interpretRoll(lootSilverPlate)
-    },
-    function () {
-      interpretRoll(lootSilverPlate)
-    },
-    function () {
-      interpretRoll(lootSilverPlate)
-    },
-    function () {
-      interpretRoll(lootSilverPlate)
-    },
-    function () {
-      interpretRoll(lootRugsTapestries)
-    },
-    function () {
-      interpretRoll(lootArt)
-    },
-    function () {
-      interpretRoll(lootMagic)
-    },
-    function () {
-      interpretRoll(lootCoins4)
-    },
-    function () {
-      interpretRoll(lootJewelry2)
-    },
+    () => interpretRoll(lootSilverPlate),
+    () => interpretRoll(lootSilverPlate),
+    () => interpretRoll(lootSilverPlate),
+    () => interpretRoll(lootSilverPlate),
+    () => interpretRoll(lootRugsTapestries),
+    () => interpretRoll(lootArt),
+    () => interpretRoll(lootMagic),
+    () => interpretRoll(lootCoins4),
+    () => interpretRoll(lootJewelry2),
     'finery (2d6 outfits)',
     'finery (2d6 outfits)'
   ];
@@ -1272,10 +1052,16 @@
   }
 
   function interpretRoll(treasure) {
-    if (typeof treasure === "string") accumulateLoot(treasure);
-    else if (typeof treasure === "function") interpretRoll(treasure());
-    else if (treasure.length === 2) accumulateLoot(treasure[0]);
-    else {
+    console.log('interpreting', treasure);
+    if (typeof treasure === "string") {
+       accumulateLoot(treasure);
+       return treasure;
+    } else if (typeof treasure === "function") {
+      return interpretRoll(treasure());
+    } else if (treasure.length === 2) {
+      accumulateLoot(treasure[0]);
+      return treasure[0];
+    } else {
       let subTableRoll = 1000;
       switch (treasure.length) {
         case 6:
@@ -1291,8 +1077,7 @@
           alert('something is wrong with the subtable roll length');
           break;
       }
-      console.log(subTableRoll + ' : ' + treasure[subTableRoll]);
-      interpretRoll(treasure[subTableRoll]);
+      return interpretRoll(treasure[subTableRoll]);
     }
   }
 
@@ -1315,7 +1100,7 @@
   }
 
   function printAccumulatedTreasure(resultsLoc) {
-    console.log(accumulatedLoot);
+    console.log('final loot', accumulatedLoot);
     let resultsVar = "Your Result:<br /><br />";
     for (const [k, v] of accumulatedLoot.entries()) {
       resultsVar += formatLootString(k, v);
@@ -1472,10 +1257,8 @@
           interpretRoll(lootTableID[lootRoll]);
         }
       }
-      printAccumulatedTreasure(resultsLoc);
     }
-
-
+    printAccumulatedTreasure(resultsLoc);
   }
 
 </script>

--- a/TorchbearerTables_2E.html
+++ b/TorchbearerTables_2E.html
@@ -827,9 +827,9 @@
     ['Thieves\' Tools', 'Ladder', 'Holy Water', 'Wolfsbane', 'Musical Instrument', 'Grappling Hook'],
     'Battle Regalia (helmet or shield, game master chooses)',
     ['Large Sack', 'Small Sack', 'Purse', 'Satchel', 'Backpack', 'Chest'],
-    () => amountAndType(1, 3, fortunateFood, 1, 6),
+    () => interpretRoll(amountAndType(1, 3, fortunateFood, 1, 6)),
     ['iron spikes', 'hammer', 'pry bar', 'chalk', 'rope', 'tinderbox'],
-    () => amountAndType(1, 3, lightSource, 1, 6),
+    () => interpretRoll(amountAndType(1, 3, lightSource, 1, 6)),
     ['skill supplies', 'skill supplies', 'skill supplies', 'skill supplies', 'spell materials', 'sacramentals'],
     () => interpretRoll(lootClothing),
     ['waterskin', 'clay pot', 'wooden canteen', 'bottle', 'jug', 'barrel'],
@@ -1054,13 +1054,16 @@
   function interpretRoll(treasure) {
     console.log('interpreting', treasure);
     if (typeof treasure === "string") {
-       accumulateLoot(treasure);
-       return treasure;
-    } else if (typeof treasure === "function") {
-      return interpretRoll(treasure());
+      // raw treasure value, therefore accumulate
+      accumulateLoot(treasure);
+      return treasure;
     } else if (treasure.length === 2) {
+      // raw treasure value, therefore accumulate
       accumulateLoot(treasure[0]);
       return treasure[0];
+    } else if (typeof treasure === "function") {
+      // this has interpretRoll baked in, which accumulates raw treasure values
+      return treasure();
     } else {
       let subTableRoll = 1000;
       switch (treasure.length) {
@@ -1077,6 +1080,7 @@
           alert('something is wrong with the subtable roll length');
           break;
       }
+      // this has interpretRoll baked in, which accumulates raw treasure values
       return interpretRoll(treasure[subTableRoll]);
     }
   }


### PR DESCRIPTION
Hi there! I think I have fixed it. I would recommend testing with small and large values of loot to make sure there is no double counting.

---

<img width="1086" alt="Screen Shot 2022-01-10 at 8 54 12 AM" src="https://user-images.githubusercontent.com/179336/148805857-37dc205d-b98c-41b4-803f-a602926d8125.png">

---

The issue you were running into with the loot tables stems from inconsistencies around whether or not the `interpretRoll` function is supposed to return something.

Here's an example loot table entry:
```javascript
// This returns "undefined"
function () {
    interpretRoll(lootJewelry2)
},
```

And here's the meat of your `interpretRoll` function:
```javascript
    if (typeof treasure === "string") accumulateLoot(treasure);
    else if (typeof treasure === "function") interpretRoll(treasure()); <--- this line right here
    else if (treasure.length === 2) accumulateLoot(treasure[0]);
    else {
```

`intepretRoll`'s purpose is to roll sub tables and accumulate loot as a side-effect. In the case when it is passed `treasure` as a function, then it tries to interpret the return value of the function. When that is `undefined`, it fails. I think since you are nesting interpret rolls here, it just makes sense to always return whatever was generated.


One other thing going on here: I changed the treasure functions to return the value of interpret roll. I could have just put `return` in front of every call to `intepretRoll`, but instead I'm using the arrow function. If you haven't encountered it before, this:

<img width="537" alt="Screen Shot 2022-01-10 at 8 00 04 AM" src="https://user-images.githubusercontent.com/179336/148803640-9f1f02be-e2d6-41d1-95d1-b7f84be982c0.png">


... is equivalent to this:

<img width="448" alt="Screen Shot 2022-01-10 at 8 41 05 AM" src="https://user-images.githubusercontent.com/179336/148803818-7f5dbb79-0f0d-4891-989c-d9b688764ecc.png">


The value is returned automatically and it looks a bit neater.
